### PR TITLE
don't force box cursor on SPC modes

### DIFF
--- a/boon-core.el
+++ b/boon-core.el
@@ -108,6 +108,7 @@ optional list of changes as its last argument."
   (setq boon-insert-state nil)
   (setq boon-special-state nil)
   (set state t)
+  (let ((previous-cursor-type cursor-type))
   (cond (boon-command-state
          ;; (do-auto-save)
          (when (and boon/insert-command boon/insert-command-history)
@@ -117,7 +118,7 @@ optional list of changes as its last argument."
          (setq boon/insert-command nil)
          (setq boon/insert-command-history nil)
          (setq cursor-type 'box))
-        (boon-special-state (setq cursor-type 'box))
+        (boon-special-state (setq cursor-type previous-cursor-type))
         (boon-insert-state
          (deactivate-mark)
          (save-excursion
@@ -130,7 +131,7 @@ optional list of changes as its last argument."
          (setq boon/insert-command-history nil)
          (setq boon/insert-origin (point)))
         (t (error "Boon: Unknown state!")))
-  (force-mode-line-update))
+  (force-mode-line-update)))
 
 (defun boon-set-insert-state ()
   "Switch to insert state."

--- a/boon-core.el
+++ b/boon-core.el
@@ -1,3 +1,4 @@
+
 ;;; boon-core.el --- An Ergonomic Command Mode  -*- lexical-binding: t -*-
 
 ;;; Commentary:
@@ -55,6 +56,9 @@ those. See `boon-special-map' for exceptions.")
 (defvar boon/insert-command nil "Command which started the insertion.")
 (defvar boon/insert-origin 0 "Point at start of insert mode.")
 
+(defvar boon/command-cursor-type 'box "Cursor type for command mode.")
+(defvar boon/insert-cursor-type 'bar "Cursor type for insert mode.")
+
 (defun boon-interactive-insert (&rest args)
   "Boon insert commands must call this function after `interactive'.
 The effect of this function is to remember the current command
@@ -95,7 +99,7 @@ optional list of changes as its last argument."
 
 (defun boon/replay-changes (changes)
   "Replay the CHANGES at the current point."
-  (let ((p0 (point)))
+  (let ((p0 (point))) 
     (setq boon/insert-command nil) ;; did not go to insert mode after all
     (dolist (change changes)
       (goto-char (+ p0 (nth 0 change)))
@@ -117,7 +121,7 @@ optional list of changes as its last argument."
                  command-history))
          (setq boon/insert-command nil)
          (setq boon/insert-command-history nil)
-         (setq cursor-type 'box))
+         (setq cursor-type boon/command-cursor-type))
         (boon-special-state (setq cursor-type previous-cursor-type))
         (boon-insert-state
          (deactivate-mark)
@@ -126,7 +130,7 @@ optional list of changes as its last argument."
              (let ((orig (point)))
                (skip-chars-forward " " (line-end-position))
                (when (eolp) (delete-region orig (point))))))
-         (setq cursor-type 'bar)
+         (setq cursor-type boon/insert-cursor-type)
          (push-mark) ;; remember where the last edition was by pushing a mark
          (setq boon/insert-command-history nil)
          (setq boon/insert-origin (point)))

--- a/boon-powerline.el
+++ b/boon-powerline.el
@@ -71,6 +71,10 @@
                                      (powerline-raw " " mode-line)
                                      (powerline-raw "%p" mode-line)
                                      (powerline-raw " " mode-line)
+                                     (if (eq major-mode 'pdf-view-mode)
+					 (concat "p"(number-to-string (pdf-view-current-page))
+						 "/"
+						 (number-to-string (pdf-cache-number-of-pages)) " "))
                                      (powerline-buffer-size mode-line nil)
                                      (powerline-raw " " mode-line)
                                      (powerline-hud mode-line face1)


### PR DESCRIPTION
So for modes likes PDFView, the SPC mode ends up with a box cursor, even though that isn't the default for the mode (and box cursor is very irritating in PDFView). This commit just lets the cursor-type for the mode filter through.