### PR TITLE
Use boon-set-search-string to escape isearch-string

### DIFF
--- a/boon-search.el
+++ b/boon-search.el
@@ -93,7 +93,7 @@ the regexp."
 
 (defadvice isearch-exit (after ysph-hl-search activate compile)
   "After isearch, highlight the search term and set it as boon current regexp."
-  (boon-set-search-regexp isearch-string))
+  (boon-set-search-string isearch-string))
 
 (provide 'boon-search)
 ;;; boon-search.el ends here


### PR DESCRIPTION
`isearch-string` should be escaped using `boon-set-search-string`.

This PR fixes https://github.com/jyp/boon/issues/57.