### PR TITLE
Remove seve-excursion from boon-qsearch-previous-at-point

### DIFF
--- a/boon-search.el
+++ b/boon-search.el
@@ -57,12 +57,7 @@ the regexp."
   "Search the previous occurence of the current string at point and select the match."
   (interactive)
   (boon-set-search-string (boon-stuff-at-point))
-  (save-excursion
-    (when (use-region-p)
-      ;; make sure that we don't find the stuff that we've just
-      ;; selected, by moving the point at the beginning of the match.
-      (goto-char (region-beginning)))
-    (boon-qsearch nil))
+  (boon-qsearch nil)
   (deactivate-mark))
 
 (defun boon-set-search-string (string)


### PR DESCRIPTION
By removing `save-excursion` from `boon-qsearch-previous-at-point`,  `boon-qsearch-previous-at-point`'s behavior becomes the same as  `boon-qsearch-next-at-point`'s one.

This PR fixes https://github.com/jyp/boon/issues/55 unless there are any special reasons that `save-excursion` is used.