### PR TITLE
Escape brackets

### DIFF
--- a/boon-main.el
+++ b/boon-main.el
@@ -353,7 +353,7 @@ Replace the region if it is active."
   "Swap the control 'bit' in EVENT, unless C-c <event> is a prefix reserved for modes."
   (interactive (list (read-key)))
   (cond
-   ((memq event '(9 13 ?{ ?} ?[ ?] ?$ ?< ?> ?: ?\; ?/ ?? ?. ?, ?' ?\")) event)
+   ((memq event '(9 13 ?{ ?} ?\[ ?\] ?$ ?< ?> ?: ?\; ?/ ?? ?. ?, ?' ?\")) event)
    ((<= event 27) (+ 96 event))
    ((not (eq 0 (logand (lsh 1 26) event))) (logxor (lsh 1 26) event))
    (t (list 'control event))))


### PR DESCRIPTION
Left square bracket and right square bracket should be escaped otherwise ``Loading ‘boon-main’: unescaped character literals `?]' detected`` message is shown when loading boon.