### PR TITLE
Update boon-spaceline for a deprecated face name

### DIFF
--- a/boon-spaceline.el
+++ b/boon-spaceline.el
@@ -15,7 +15,7 @@
   "Boon status"
   (boon-state-string)
   :when (bound-and-true-p boon-mode)
-  :face (if (powerline-selected-window-active) (boon-state-face) 'modeline-inactive))
+  :face (if (powerline-selected-window-active) (boon-state-face) 'mode-line-inactive))
 
 
 


### PR DESCRIPTION
The face `modeline-inactive` has been deprecated in favor of `mode-line-inactive` in Emacs 22.1. This PR updates the reference, which makes `boon-spaceline` correctly render on spaceline in all circumstances.