### PR TITLE
Support vterm

### DIFF
--- a/boon-core.el
+++ b/boon-core.el
@@ -173,7 +173,7 @@ input-method is reset to nil.)")
     :type '(repeat symbol))
 
 (defun boon-shell-mode-p ()
-  (derived-mode-p 'comint-mode 'eshell-mode 'term-mode))
+  (derived-mode-p 'comint-mode 'eshell-mode 'term-mode 'vterm-mode))
 
 (defcustom boon-special-conditions
   '((bound-and-true-p magit-blame-mode))


### PR DESCRIPTION
In `boon-shell-mode-p` check additionally for `'vterm-mode`.  Enables boon usage when using `vterm` (now supported by projectile...).