### PR TITLE
Add universal-argument-more key binding

### DIFF
--- a/boon-keys.el
+++ b/boon-keys.el
@@ -72,6 +72,7 @@
 (dolist (number '("0" "1" "2" "3" "4" "5" "6" "7" "8" "9"))
   (define-key boon-command-map number 'digit-argument))
 (define-key boon-command-map "~" 'universal-argument)
+(define-key universal-argument-map "~" 'universal-argument-more)
 
 (defcustom boon-quit-key [escape] "Key to go back to command
 state and generally exit local states and modes." :group 'boon


### PR DESCRIPTION
The universal-argument key binding "~ " does not work when pressing twice. Pressing "~ ~ " should do the same as pressing "C-u C-u". The universal-argument-more command should be bound to "~" in the universal-argument-map for this.