### PR TITLE
Make spaceline install optional; fixes #89

### DIFF
--- a/boon-spaceline.el
+++ b/boon-spaceline.el
@@ -8,7 +8,7 @@
 
 (require 'boon-core)
 (require 'boon-powerline)
-(require 'spaceline-config)
+(require 'spaceline-config nil t)
 
 ;; This requires https://github.com/TheBB/spaceline/pull/201/commits/45c4c4b26d923c541ede138c3b3834e2f75778f8 to work.
 (spaceline-define-segment boon


### PR DESCRIPTION
To be able to compile boon currently spaceline needs to be installed. As not all users will want to use spaceline this should be an optional dependency instead as done in this commit.