### PR TITLE
Add 1 set of alternative mappings

### DIFF
--- a/boon-arguments.el
+++ b/boon-arguments.el
@@ -302,8 +302,8 @@ subregions or when repeating a command.  The bounds that are
 eventually returned are in the form of a list of regs.  See
 boon-regs.el."
   (let ((my-prefix-arg 0)
-        (kmv boon-moves-map)
-        (kms boon-select-map))
+        (kmv (if boon-using-altp boon-alt-moves-map boon-moves-map))
+        (kms (if boon-using-altp boon-alt-select-map boon-select-map)))
     ;; We read a move or selection, in both keymaps in parallel. First command found wins.
     (while (and (or kmv kms) (not (commandp kms)) (not (commandp kmv)))
       (let ((last-char (read-event (format "%s %s" msg my-prefix-arg))))

--- a/boon-core.el
+++ b/boon-core.el
@@ -38,13 +38,32 @@ Any move is also a valid region selector, see `boon-moves-map'.")
 See also `boon-special-mode-list'.
 
 \\{boon-special-map}")
+;; Alternate maps
+(defvar boon-alt-command-map (make-sparse-keymap)
+  "Alternate keymap used in Boon command mode.
+
+\\{boon-alt-command-map}")
+(suppress-keymap boon-alt-command-map 't)
+(defvar boon-alt-moves-map (make-sparse-keymap)
+  "Alternate keymap for moves (subset of alt command mode).
+
+\\{boon-alt-moves-map}")
+(set-keymap-parent boon-alt-command-map boon-alt-moves-map)
+
+(defvar boon-alt-select-map (make-sparse-keymap)
+  "Alternate keymap for text regions selectors.
+\\{boon-alt-select-map}
+
+Any move is also a valid region selector, see `boon-alt-moves-map'.")
 
 (defvar-local boon-mode-map-alist nil)
 (push 'boon-mode-map-alist emulation-mode-map-alists)
 
 ;; States
+(defvar boon-using-altp nil "Non-nil when the alternate keymap is active.")
 (defvar-local boon-off-state nil "Used to disable boon altogether without fiddling with emulation-mode-map-alists")
 (defvar-local boon-command-state nil "Non-nil when boon command mode is activated. (Boon commands can be entered in this mode.)")
+(defvar-local boon-alt-command-state nil "Non-nil when boon alt command mode is activated. (Boon alt commands can be entered in this mode.)")
 (defvar-local boon-insert-state nil "Non-nil when boon insert mode is activated.")
 (defvar-local boon-special-state nil "Non-nil when special state is
 activated. Special is active when special-mode buffers (see `boon-special-mode-list') are
@@ -57,6 +76,7 @@ those. See `boon-special-map' for exceptions.")
 
 (defcustom boon-default-cursor-type 'bar "Default `cursor-type', also used for the minibuffer." :group 'boon :type 'sexp)
 (defcustom boon-command-cursor-type 'box "`cursor-type' for command mode." :group 'boon :type 'sexp)
+(defcustom boon-alt-command-cursor-type 'box "`cursor-type' for command mode." :group 'boon :type 'sexp)
 (defcustom boon-insert-cursor-type 'bar "`cursor-type' for insert mode." :group 'boon :type 'sexp)
 (defcustom boon-special-cursor-type 'box "`cursor-type' for special mode." :group 'boon :type 'sexp)
 
@@ -73,6 +93,13 @@ of `boon-command-cursor-color', `boon-insert-cursor-color' and
   :type 'string)
 (defcustom
   boon-command-cursor-color
+  nil
+  "`cursor-color' for command mode.  `boon-default-cursor-color'
+must also be set."
+  :group 'boon
+  :type 'string)
+(defcustom
+  boon-alt-command-cursor-color
   nil
   "`cursor-color' for command mode.  `boon-default-cursor-color'
 must also be set."
@@ -101,6 +128,7 @@ must also be set."
         (cond
          (boon-insert-state (list boon-insert-cursor-type boon-insert-cursor-color))
          (boon-command-state (list boon-command-cursor-type boon-command-cursor-color))
+         (boon-alt-command-state (list boon-alt-command-cursor-type boon-alt-command-cursor-color))
          (boon-special-state (list boon-special-cursor-type boon-special-cursor-color))
          (t (list boon-default-cursor-type boon-default-cursor-color)))
       (setq cursor-type type)
@@ -170,10 +198,11 @@ input-method is reset to nil.)")
   "Set the boon state (as STATE) for this buffer."
   (when boon-insert-state (setq-local boon-input-method current-input-method))
   (setq boon-command-state nil)
+  (setq boon-alt-command-state nil)
   (setq boon-insert-state nil)
   (setq boon-special-state nil)
   (set state t)
-  (cond (boon-command-state
+  (cond ((or boon-command-state boon-alt-command-state)
          (deactivate-input-method)
          (when (and boon/insert-command boon/insert-command-history)
            (push `(,@boon/insert-command
@@ -207,7 +236,28 @@ input-method is reset to nil.)")
 
 (defun boon-set-command-state ()
   "Switch to command state."
-  (interactive) (boon-set-state 'boon-command-state))
+  (interactive)
+  (setq boon-using-altp nil)
+  (boon-set-state 'boon-command-state))
+
+(defun boon-set-alt-command-state ()
+  "Switch to alt command state."
+  (interactive)
+  (setq boon-using-altp t)
+  (boon-set-state 'boon-alt-command-state))
+
+(defun boon-restore-command-state ()
+  "Switch to command or alt command mode."
+  (interactive)
+  (if boon-using-altp
+      (boon-set-alt-command-state)
+    (boon-set-command-state)))
+
+(defun boon-toggle-alt ()
+  "Swap between command-mode and alt-command-mode globally."
+  (interactive)
+  (setq boon-using-altp (not boon-using-altp))
+  (boon-restore-command-state))
 
 (defun boon-set-special-state ()
   "Switch to special state."
@@ -249,6 +299,13 @@ input-method is reset to nil.)")
       (-some 'eval boon-special-conditions)
       (memq major-mode boon-special-mode-list)))
 
+(defun boon-initialize-state ()
+  (cond ((boon-special-mode-p) (boon-set-state 'boon-special-state))
+          ((-some 'eval boon-insert-conditions) (boon-set-insert-state))
+          (t (boon-restore-command-state))))
+
+(add-hook 'buffer-list-update-hook #'boon-initialize-state)
+
 ;;; Initialisation and activation
 
 (define-minor-mode boon-local-mode
@@ -260,13 +317,12 @@ input-method is reset to nil.)")
       (boon-set-state 'boon-off-state)
     (setq boon-mode-map-alist
           (list (cons 'boon-command-state (or (get major-mode 'boon-map) boon-command-map))
+                (cons 'boon-alt-command-state (or (get major-mode 'boon-map) boon-alt-command-map))
                 (cons 'boon-special-state boon-special-map)
                 (cons 'boon-insert-state  boon-insert-map)))
     (unless (memq 'boon/after-change-hook after-change-functions)
       (push 'boon/after-change-hook after-change-functions))
-    (cond ((boon-special-mode-p) (boon-set-state 'boon-special-state))
-          ((-some 'eval boon-insert-conditions) (boon-set-insert-state))
-          (t (boon-set-command-state)))))
+    (boon-initialize-state)))
 
 (add-hook 'minibuffer-setup-hook 'boon-minibuf-hook)
 
@@ -307,6 +363,7 @@ the buffer changes."
   "Return a string describing the current state."
   (cond
    (boon-command-state "CMD")
+   (boon-alt-command-state "ACMD")
    (boon-insert-state  "INS")
    (boon-special-state "SPC")
    (t "???")))

--- a/boon-keys.el
+++ b/boon-keys.el
@@ -51,11 +51,20 @@
 (define-key boon-select-map "#"  'boon-select-all)
 (define-key boon-select-map " "  'boon-select-line)
 (define-key boon-select-map  "\"" 'boon-select-outside-quotes)
+(define-key boon-alt-select-map "@"  'boon-select-occurences)
+(define-key boon-alt-select-map "#"  'boon-select-all)
+(define-key boon-alt-select-map " "  'boon-select-line)
+(define-key boon-alt-select-map  "\"" 'boon-select-outside-quotes)
 (define-key boon-moves-map  "'" 'boon-switch-mark)
 (define-key boon-moves-map  (kbd "<left>") 'left-char)
 (define-key boon-moves-map  (kbd "<right>") 'right-char)
 (define-key boon-moves-map  (kbd "<up>") 'previous-line)
 (define-key boon-moves-map  (kbd "<down>") 'next-line)
+(define-key boon-alt-moves-map  "'" 'boon-switch-mark)
+(define-key boon-alt-moves-map  (kbd "<left>") 'left-char)
+(define-key boon-alt-moves-map  (kbd "<right>") 'right-char)
+(define-key boon-alt-moves-map  (kbd "<up>") 'previous-line)
+(define-key boon-alt-moves-map  (kbd "<down>") 'next-line)
 
 (define-key boon-command-map "'" 'boon-toggle-mark)
 (define-key boon-command-map [(return)] 'undefined)
@@ -63,15 +72,25 @@
 (define-key boon-command-map [(backspace)] 'undefined)
 (define-key boon-command-map (kbd "<DEL>") 'undefined)
 (define-key boon-command-map "`" 'boon-toggle-case)
-(define-key boon-moves-map "[" '("[-" . boon-navigate-backward))
-(define-key boon-moves-map "]" '("-]" . boon-navigate-forward))
+(define-key boon-alt-command-map "'" 'boon-toggle-mark)
+(define-key boon-alt-command-map [(return)] 'undefined)
+(define-key boon-alt-command-map (kbd "<RET>") 'undefined)
+(define-key boon-alt-command-map [(backspace)] 'undefined)
+(define-key boon-alt-command-map (kbd "<DEL>") 'undefined)
+(define-key boon-alt-command-map "`" 'boon-toggle-case)
+(define-key boon-alt-moves-map "[" '("[-" . boon-navigate-backward))
+(define-key boon-alt-moves-map "]" '("-]" . boon-navigate-forward))
 
 (define-key boon-command-map "!" 'shell-command)
 (define-key boon-command-map "|" 'shell-command-on-region)
 (define-key boon-command-map "-" 'undo)
+(define-key boon-alt-command-map "!" 'shell-command)
+(define-key boon-alt-command-map "|" 'shell-command-on-region)
+(define-key boon-alt-command-map "-" 'undo)
 (dolist (number '("0" "1" "2" "3" "4" "5" "6" "7" "8" "9"))
   (define-key boon-command-map number 'digit-argument))
 (define-key boon-command-map "~" 'universal-argument)
+(define-key boon-alt-command-map "~" 'universal-argument)
 (define-key universal-argument-map "~" 'universal-argument-more)
 
 (defcustom boon-quit-key [escape] "Key to go back to command
@@ -80,16 +99,18 @@ state and generally exit local states and modes." :group 'boon
 
 (define-key boon-command-map " " 'boon-drop-mark)
 (define-key boon-command-map boon-quit-key 'boon-quit)
+(define-key boon-alt-command-map " " 'boon-drop-mark)
+(define-key boon-alt-command-map boon-quit-key 'boon-quit)
 
 ;; Special mode rebinds
 (define-key boon-special-map "`" 'boon-quote-character)
 (define-key boon-special-map "'" 'boon-quote-character)
 (define-key boon-special-map "x" boon-x-map)
-(define-key boon-special-map boon-quit-key 'boon-set-command-state)
+(define-key boon-special-map boon-quit-key 'boon-restore-command-state)
 
 ;;  Insert mode rebinds
 (define-key boon-insert-map [remap newline] 'boon-newline-dwim)
-(define-key boon-insert-map boon-quit-key 'boon-set-command-state)
+(define-key boon-insert-map boon-quit-key 'boon-restore-command-state)
 
 ;; Global rebinds
 (define-key global-map boon-quit-key 'keyboard-quit)


### PR DESCRIPTION
Hi, thank you so much for Boon. I have been using it for about a year. I have a great love for it.

This code adds an ACMD alternate command state, 3 alt keymaps, and a global var to toggle between the default set and the alternate set. This is my fix for wanting to switch between Qwerty and Dvorak mappings seamlessly. The changes also automatically put you in CMD / SPC / ACMD (alternate command) automatically whenever you switch to a buffer. this will clobber your INS buffers, which is actually by preference, but that's besides the point.

I don't necessarily think this is a best solution to my problem nor fit for general use, I just wanted to share some code, share the problem I was facing, and start a discussion. Maybe there is a code contribution somewhere here but that's not up to me :)

As alternatives before doing this, I tried adjusting the keymaps after boon-mode is initialized. But I had some issues. Ex in qwerty c calls boon-c-god but in Dvorak I wanted it to be previous-line. When I deleted "c" from boon-command-map and then mapped "c" in boon-moves-map, I would get "c" is undefined. I didn't look into the root cause of this :) It seemed like the alist of maps which power boon-local-mode was getting out of sync with the keymap vars, but I'm not sure why.

I also tried making it easy to restart emacs with desktop.el. This did work but it was not seamless. There is some friction to switch as I would have to change my config using the wrong keymaps, then restart emacs. I usually got mixed up too, I would restart emacs without change the config the first time and have to try again. And desktop.el I found a bit tricky to use as well.

Here is my current config which lets me call simple `M-x boon-toggle-alt` to switch between Qwerty and Dvorak.

```elisp
(use-package boon
  :load-path "~/.emacs.d/boon/"
  :bind (:map boon-moves-map
	      ("i" . next-line)
	      ("o" . previous-line)
	      ("k" . backward-char)
	      ("l" . forward-char)
	      ("u" . boon-beginning-of-line)
	      ("p" . boon-end-of-line)
	      ("j" . boon-smarter-backward)
	      (":" . boon-smarter-forward)
	      ("<" . beginning-of-buffer)
	      (">" . end-of-buffer)
	      ("I" . forward-paragraph)
	      ("O" . backward-paragraph)
         :map boon-command-map
              ("a" . sc/duplicate-line)
              ("s" . boon-substitute-region)
              ("d" . boon-take-region)
              ("D" . boon-treasure-region)
              ("f" . boon-splice)
	      ("F" . yank-pop)
              ("v" . boon-set-insert-like-state)
              ("V" . boon-open-next-line-and-insert)
              ("C-v" . boon-open-line-and-insert)
              ("x" . boon-x-map)
              ("c" . boon-c-god)
              ("m" . xref-find-definitions)
              ("M" . xref-find-references)
              ("n" . xref-pop-marker-stack)
              ("<RET>" . newline)
	 :map boon-alt-moves-map
	      ("c" . next-line)
	      ("r" . previous-line)
	      ("t" . backward-char)
	      ("n" . forward-char)
	      ("g" . boon-beginning-of-line)
	      ("l" . boon-end-of-line)
	      ("h" . boon-smarter-backward)
	      ("s" . boon-smarter-forward)
	      ("W" . beginning-of-buffer)
	      ("V" . end-of-buffer)
	      ("C" . forward-paragraph)
	      ("R" . backward-paragraph)
         :map boon-alt-command-map
              ("a" . sc/duplicate-line)
              ("o" . boon-substitute-region)
              ("e" . boon-take-region)
              ("E" . boon-treasure-region)
              ("u" . boon-splice)
	      ("U" . yank-pop)
              ("k" . boon-set-insert-like-state)
              ("K" . boon-open-next-line-and-insert)
              ("C-k" . boon-open-line-and-insert)
              ("q" . boon-x-map)
              ("j" . boon-c-god)
              ("m" . xref-find-definitions)
              ("M" . xref-find-references)
              ("b" . xref-pop-marker-stack)
              ("<RET>" . newline)
	 :map boon-insert-map
              ([remap newline] . nil)
	 :map boon-select-map
	      ("s" . boon-select-wim)
	      ("b" . boon-select-blanks)
	 :map boon-alt-select-map
	      ("o" . boon-select-wim)
	      ("x" . boon-select-blanks))
  :init
  (boon-mode)
  (boon-toggle-alt))
```