### PR TITLE
Honor command remapping in boon-quote-character

### DIFF
--- a/boon-main.el
+++ b/boon-main.el
@@ -344,9 +344,11 @@ Replace the region if it is active."
 (defun boon-quote-character (char)
   "Execute the command which were bound to the character CHAR if boon was not enabled."
   (interactive (list (read-char))) ;; use read-char so that multiple-cursors advice kicks in.
-  (let ((cmd (lookup-key (make-composed-keymap
-                          (let ((boon-mode-map-alist nil)) (current-active-maps)))
-                         (vector char))))
+  (let* ((keymap (make-composed-keymap
+                  (let ((boon-mode-map-alist nil)) (current-active-maps))))
+         (cmd (lookup-key keymap (vector char)))
+         (cmd (or (command-remapping cmd nil keymap)
+                  cmd)))
     (setq last-command-event char)
     (message "Executing the command bound to %c" char)
     (call-interactively cmd nil [char])))


### PR DESCRIPTION
When using boon-special-state in magit status buffers, `boon-quote-character` is not always running command as in insert state. For example, trying to pass `k` with point on an unstaged hunk supposed to run `magit-discard-hunk` but actually runs `magit-delete-thing`.

The problem happens because `magit-discard-hunk` is remapped from `magit-delete-thing` in the local keymap defined in hunk text properties. `boon-quote-character` currently searches for the direct binding only (i.e. `magit-delete-thing`) and not honoring the remapping. The patch fixes the issue.