### PR TITLE
boon-reset-state-for-switchw: Accept a frame as the argument

### DIFF
--- a/boon-core.el
+++ b/boon-core.el
@@ -372,18 +372,19 @@ the buffer changes."
                   boon-toggle-character-case
                   boon-toggle-case))))
 
+(defun boon-reset-state-for-switchw (frame-or-window)
+  "Reset the boon state to natural when switching windows."
+  (let* ((old (if (framep frame-or-window)
+                  (frame-old-selected-window (old-selected-frame))
+                (old-selected-window)))
+         (prev-buf (window-buffer old)))
+    (with-current-buffer prev-buf
+      (boon-set-natural-state))))
+
 ;; When switching away from a window (for example by clicking in
 ;; another window), return the buffer hosting it to its "natural"
 ;; state (otherwise it's surprising to the user when coming back to it)
-(add-hook 'window-selection-change-functions
-          (defun boon-reset-state-for-switchw (frame-or-window)
-            "Reset the boon state to natural when switching windows."
-            (let* ((old (if (framep frame-or-window)
-                            (frame-old-selected-window (old-selected-frame))
-                          (old-selected-window)))
-                   (prev-buf (window-buffer old)))
-              (with-current-buffer prev-buf
-                (boon-set-natural-state)))))
+(add-hook 'window-selection-change-functions #'boon-reset-state-for-switchw)
 
 (defadvice isearch-exit (after boon-isearch-set-search activate compile)
   "After isearch, highlight the search term."

--- a/boon-core.el
+++ b/boon-core.el
@@ -376,9 +376,11 @@ the buffer changes."
 ;; another window), return the buffer hosting it to its "natural"
 ;; state (otherwise it's surprising to the user when coming back to it)
 (add-hook 'window-selection-change-functions
-          (defun boon-reset-state-for-switchw (window)
+          (defun boon-reset-state-for-switchw (frame-or-window)
             "Reset the boon state to natural when switching windows."
-            (let* ((old (old-selected-window))
+            (let* ((old (if (framep frame-or-window)
+                            (frame-old-selected-window (old-selected-frame))
+                          (old-selected-window)))
                    (prev-buf (window-buffer old)))
               (with-current-buffer prev-buf
                 (boon-set-natural-state)))))

--- a/boon-core.el
+++ b/boon-core.el
@@ -374,12 +374,16 @@ the buffer changes."
 
 (defun boon-reset-state-for-switchw (frame-or-window)
   "Reset the boon state to natural when switching windows."
-  (let* ((old (if (framep frame-or-window)
-                  (frame-old-selected-window (old-selected-frame))
-                (old-selected-window)))
-         (prev-buf (window-buffer old)))
-    (with-current-buffer prev-buf
-      (boon-set-natural-state))))
+  (let* ((old-frame-or-window (old-selected-window))
+         (old-window (when old-frame-or-window
+                       (if (framep old-frame-or-window)
+                           (when (frame-live-p old-frame-or-window)
+                             (frame-old-selected-window old-frame-or-window))
+                         old-frame-or-window)))
+         (old-buffer (when old-window (window-buffer old-window))))
+    (when old-buffer
+      (with-current-buffer old-buffer
+        (boon-set-natural-state)))))
 
 ;; When switching away from a window (for example by clicking in
 ;; another window), return the buffer hosting it to its "natural"


### PR DESCRIPTION
`window-selection-change-functions` may be called with a frame instead of a window when the selected frame has changed. In particular, this happens at startup when the initial frame is created. When compiled natively, the type mismatch (`framep` instead of `windowp`) may cause a segmentation fault.