### PR TITLE
Add bindings to `boon-emacs.el`

### DIFF
--- a/boon-emacs.el
+++ b/boon-emacs.el
@@ -110,6 +110,7 @@
 (define-key boon-command-map "?" 'describe-mode)
 (define-key boon-command-map "h" 'describe-mode)
 (define-key boon-command-map "q" '("quit" . quit-window))
+(define-key boon-command-map "^" 'delete-indentation)
 
 (define-key indent-rigidly-map "k" 'indent-rigidly-right)
 (define-key indent-rigidly-map "l" 'indent-rigidly-left)

--- a/boon-emacs.el
+++ b/boon-emacs.el
@@ -54,7 +54,7 @@
 (define-key boon-select-map "T" 'boon-select-org-tree)
 (define-key boon-select-map "G" 'boon-select-org-table-cell)
 
-(define-key boon-moves-map "x" 'boon-switch-mark)
+(define-key boon-moves-map "@" 'boon-switch-mark)
 (define-key boon-moves-map "p" '("previous" . previous-line))
 (define-key boon-moves-map "n" '("next" . next-line))
 (define-key boon-moves-map "{" 'backward-paragraph)

--- a/boon-emacs.el
+++ b/boon-emacs.el
@@ -111,6 +111,7 @@
 (define-key boon-command-map "h" 'describe-mode)
 (define-key boon-command-map "q" '("quit" . quit-window))
 (define-key boon-command-map "^" 'delete-indentation)
+(define-key boon-command-map "\\" 'indent-region)
 
 (define-key indent-rigidly-map "k" 'indent-rigidly-right)
 (define-key indent-rigidly-map "l" 'indent-rigidly-left)

--- a/boon-emacs.el
+++ b/boon-emacs.el
@@ -112,6 +112,8 @@
 (define-key boon-command-map "q" '("quit" . quit-window))
 (define-key boon-command-map "^" 'delete-indentation)
 (define-key boon-command-map "\\" 'indent-region)
+(define-key boon-command-map "v" 'scroll-up-command)
+(define-key boon-command-map "V" 'scroll-down-command)
 
 (define-key indent-rigidly-map "k" 'indent-rigidly-right)
 (define-key indent-rigidly-map "l" 'indent-rigidly-left)


### PR DESCRIPTION
I've used these in my personal config for a while and think they are useful upstream as well. Each commit stands on its own, so feel free to mix & match as you see fit.

Regarding `boon-switch-mark`: `x` is shadowed by `boon-command-map`. `@` was the shortcut for `boon-switch-mark` in version 1 of boon-emacs.el, so it feels like a natural choice to return to that.

Default keybindings in Emacs and the new bindings in this PR:

- `delete-indentation`: `M-^` => `^` in `boon-command-map`
- `indent-region`: `C-M-\` => `\` in `boon-command-map`
- `scroll-up-command`: `C-v` => `v` in `boon-command-map`
- `scroll-down-command`: `M-v` => `V` in `boon-command-map`