### PR TITLE
Don't reset the last buffer state if we can't find it

### DIFF
--- a/boon-core.el
+++ b/boon-core.el
@@ -368,16 +368,17 @@ the buffer changes."
                   boon-toggle-character-case
                   boon-toggle-case))))
 
-;; When switching away from a window (for example by clicking in
-;; another window), return the buffer hosting it to its "natural"
-;; state (otherwise it's surprising to the user when coming back to it)
-(add-hook 'window-selection-change-functions
-          (defun boon-reset-state-for-switchw (window)
-            "Reset the boon state to natural when switching windows."
-            (let* ((old (old-selected-window))
-                   (prev-buf (window-buffer old)))
-              (with-current-buffer prev-buf
-                (boon-set-natural-state)))))
+;; When switching away from a window (for example by clicking in another
+;; window), return the buffer hosting it to its "natural" state (otherwise it's
+;; surprising to the user when coming back to it).
+(defun boon-reset-state-for-switchw (new-frame)
+  "Reset the boon state to natural when switching windows."
+  (let* ((old (old-selected-window))
+         (prev-buf (window-buffer old)))
+    (with-current-buffer prev-buf
+      (boon-set-natural-state))))
+
+(add-hook 'window-selection-change-functions #'boon-reset-state-for-switchw)
 
 (defadvice isearch-exit (after boon-isearch-set-search activate compile)
   "After isearch, highlight the search term."

--- a/boon-core.el
+++ b/boon-core.el
@@ -373,9 +373,10 @@ the buffer changes."
 ;; surprising to the user when coming back to it).
 (defun boon-reset-state-for-switchw (new-frame)
   "Reset the boon state to natural when switching windows."
-  (let* ((old (old-selected-window))
-         (prev-buf (window-buffer old)))
-    (with-current-buffer prev-buf
+  (-when-let* ((old-frame-or-window (old-selected-window))  ; `old-selected-window' sometimes (surprisingly) returns a frame.
+               (old-window (and (windowp old-frame-or-window) old-frame-or-window))
+               (old-buffer (window-buffer old-window)))
+    (with-current-buffer old-buffer
       (boon-set-natural-state))))
 
 (add-hook 'window-selection-change-functions #'boon-reset-state-for-switchw)


### PR DESCRIPTION
This pull request makes two changes:

1. Move the definition of `boon-reset-state-for-switchw` to the top level. This makes it easier to attach the debugger or override the definition.
2. Don't try to reset the state of the old selected buffer if we can't find it. Sometimes, the old selected window is `nil` (e.g. at Emacs startup). Or, we might be given a frame instead of a window.