### PR TITLE
Fix definition of `boon-command-map`

### DIFF
--- a/boon-core.el
+++ b/boon-core.el
@@ -27,7 +27,8 @@
 
 (defvar boon-command-map (let ((map (make-sparse-keymap)))
                            (suppress-keymap map 't)
-                           (set-keymap-parent map boon-moves-map))
+                           (set-keymap-parent map boon-moves-map)
+                           map)
   "Keymap used in Boon command mode.
 \\{boon-command-map}")
 


### PR DESCRIPTION
`set-keymap-parent` returns the parent keymap, `boon-moves-map` in this case.

Before this fix, keys not bound in `boon-command-map` and `boon-moves-map` ended up calling `self-insert-command`. I.e. `suppress-keymap` had no effect.

I've used this a couple of days now and did not observe any unwanted side effects.